### PR TITLE
Add CRUD operations + {create,drop} table

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,11 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/node:10.14
+    working_directory: ~/omg
+
+    steps:
+      - checkout
+      - run: npm i omg
+      - run: npx omg build

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,125 @@
+
+# Created by https://www.gitignore.io/api/python
+# Edit at https://www.gitignore.io/?templates=python
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+### Python Patch ###
+.venv/
+
+# End of https://www.gitignore.io/api/python

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,13 @@
 FROM          python:3.7-alpine
 
 RUN           mkdir /app
-
 COPY          requirements.txt /app
-RUN           pip install -r /app/requirements.txt
+
+RUN apk update && \
+ apk add postgresql-libs && \
+ apk add --virtual .build-deps gcc musl-dev postgresql-dev && \
+ pip install -r /app/requirements.txt --no-cache-dir && \
+ apk --purge del .build-deps
 
 COPY          app.py /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM          python:3.6.6
+FROM          python:3.7-alpine
 
 RUN           mkdir /app
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,98 @@
 # Asyncy Postgres
 
-This container should be used for raw psql access.
-The output is always returned in JSON format.
+Interact with a Postgres database.
 
-#### Example
+Examples
+-------
+
+### Create table
+
+A table can be created with `create_table`:
+
+```coffee
+# Storyscript
+psql create_table table: 'books' columns: {
+  'id': 'serial primary key',
+  'title': 'varchar(100)'
+}
+```
+
+### Insert an entry
+
+```coffee
+# Storyscript
+psql insert table: 'books' values: {'title': 'Ulysses'}
+# result: {'id': 1, 'title': 'Ulysses'}
+```
+
+### Insert multiple entries
+
+```coffee
+# Storyscript
+psql insert table: 'books' values: [{'title': 'Moby Dick'}, {'title': 'War and Peace'}]
+# result: [{'id': 2, 'title': 'Ulysses'}, {'id': 3, 'title': 'War and Peace'}]
+```
+
+### Select entries
+
+- `$and` and `$or` can be used to combine queries
+- `$lt`, `$lte`, `$gt`, `$gte` and `$eq` can be used as comparison operators
+- if no comparison operators is provided, the query will match on equality
+
+```coffee
+# Storyscript
+psql select table: 'books' where: {'title': 'Moby Dick'}
+# result: [{'id': 2, title: 'Moby Dick'}]
+```
+
+```coffee
+# Storyscript
+psql select table: 'books' where: {'$or': {title: 'Moby Dick', 'id: {'$lt': 2}}}
+# result: [{'id': 1, 'title': 'Ulysses'}, {'id': 2, title: 'Moby Dick'}]
+```
+
+### Update entries
+
+```coffee
+# Storyscript
+psql update table: 'books' values: {'title': 'UPDATED'} where: {'id': {'$gt': 2}}
+# result: [{'id': 3, title: 'UPDATED'}]
+```
+
+The where query is optional, but without it _all_ columns will be updated:
+
+```coffee
+# Storyscript
+psql update table: 'books' values: {'title': 'UPDATED'}
+# result: [
+#     {'id': 1, 'title': 'Ulysses'},
+#     {'id': 2, 'title': 'Ulysses'},
+#     {'id': 3, 'title': 'War and Peace'}
+# ]
+```
+
+### Delete entries
+
+`delete` uses a `where` select query and will return the deleted columns:
+
+```coffee
+# Storyscript
+psql delete table: 'books' where: {'title': 'Moby Dick'}
+# result: [{'id': 2, title: 'Moby Dick'}]
+```
+
+The where query is optional, but without it _all_ columns will be deleted.
+
+### Drop table
+
+An entire table can be dropped with `drop_table`:
+
+```coffee
+# Storyscript
+psql drop_table table: 'books'
+```
+
+### Execute
 
 ```storyscript
 # Storyscript

--- a/README.md
+++ b/README.md
@@ -42,13 +42,13 @@ psql insert table: 'books' values: [{'title': 'Moby Dick'}, {'title': 'War and P
 ```coffee
 # Storyscript
 psql select table: 'books' where: {'title': 'Moby Dick'}
-# result: [{'id': 2, title: 'Moby Dick'}]
+# result: [{'id': 2, 'title': 'Moby Dick'}]
 ```
 
 ```coffee
 # Storyscript
-psql select table: 'books' where: {'$or': {title: 'Moby Dick', 'id: {'$lt': 2}}}
-# result: [{'id': 1, 'title': 'Ulysses'}, {'id': 2, title: 'Moby Dick'}]
+psql select table: 'books' where: {'$or': {title: 'Moby Dick', 'id': {'$lt': 2}}}
+# result: [{'id': 1, 'title': 'Ulysses'}, {'id': 2, 'title': 'Moby Dick'}]
 ```
 
 ### Update entries
@@ -56,7 +56,7 @@ psql select table: 'books' where: {'$or': {title: 'Moby Dick', 'id: {'$lt': 2}}}
 ```coffee
 # Storyscript
 psql update table: 'books' values: {'title': 'UPDATED'} where: {'id': {'$gt': 2}}
-# result: [{'id': 3, title: 'UPDATED'}]
+# result: [{'id': 3, 'title': 'UPDATED'}]
 ```
 
 The where query is optional, but without it _all_ columns will be updated:
@@ -78,7 +78,7 @@ psql update table: 'books' values: {'title': 'UPDATED'}
 ```coffee
 # Storyscript
 psql delete table: 'books' where: {'title': 'Moby Dick'}
-# result: [{'id': 2, title: 'Moby Dick'}]
+# result: [{'id': 2, 'title': 'Moby Dick'}]
 ```
 
 The where query is optional, but without it _all_ columns will be deleted.

--- a/app.py
+++ b/app.py
@@ -12,21 +12,242 @@ from psycopg2.extras import RealDictCursor
 app = Flask(__name__)
 
 
+def postgres_dsn():
+    """
+    Returns the DSN string for connecting with postgres
+    """
+    return os.environ.get('POSTGRES_DSN')
+
+
+class SimplePostgres:
+    """
+    Provides a cursor to connection to Postgres instance in a with context.
+    """
+
+    def __enter__(self):
+        """
+        Starts a connection to a Postgres instance
+        """
+        self.conn = psycopg2.connect(
+            postgres_dsn(),
+            cursor_factory=RealDictCursor
+        )
+        self.cursor = self.conn.cursor()
+        return self.cursor
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        try:
+            self.conn.commit()
+        # There's an exception listener, so we want to re-raise the exception
+        # But make sure all connections are properly closed
+        except Exception as e:
+            raise e
+        finally:
+            self.cursor.close()
+            self.conn.close()
+
+
 @app.route('/execute', methods=['post'])
 def execute():
     req = request.json
     query = req['query']
     args = req.get('data', {})
-    with psycopg2.connect(os.environ.get('POSTGRES_DSN'),
-                          cursor_factory=RealDictCursor) as conn:
-        with conn.cursor() as cur:
-            cur.execute(query, args)
+    with SimplePostgres() as cur:
+        cur.execute(query, args)
+        return jsonify(cur.fetchall())
+
+
+class InsertBuilder:
+    """
+    Builds an insert query string for one or more insert instructions
+    """
+
+    def __init__(self):
+        self.params = []
+        self.value_strs = []
+        self.first_item = None
+
+    def add(self, values):
+        items = sorted(values.items())
+        # save the first item for the column names
+        if self.first_item is None:
+            self.first_item = items
+
+        self.params.extend(map(lambda x: x[1], items))
+        self.value_strs.append(f"({','.join(map(lambda x: '%s', values))})")
+
+    def names(self):
+        return ','.join(map(lambda x: f'"{x[0]}"', self.first_item))
+
+    def values(self):
+        return ','.join(self.value_strs)
+
+
+@app.route('/insert', methods=['post'])
+def insert():
+    builder = InsertBuilder()
+    req = request.json
+    table = req['table']
+    values = req['values']
+    # allow one or multiple insert entries
+    if isinstance(values, list):
+        for e in values:
+            builder.add(e)
+    else:
+        builder.add(values)
+    sql = (f"INSERT INTO {table} ({builder.names()}) "
+           f"VALUES {builder.values()} RETURNING *")
+    with SimplePostgres() as cur:
+        cur.execute(sql, builder.params)
+        if isinstance(values, list):
             return jsonify(cur.fetchall())
+        else:
+            return jsonify(cur.fetchone())
+
+
+class QueryBuilder:
+    """
+    Builds a simple select query string
+    """
+
+    operators = {
+        "$gt": ">",
+        "$gte": ">=",
+        "$lt": "<",
+        "$lte": "<=",
+        "$eq": "=",
+    }
+
+    def __init__(self):
+        self.params = []
+        self.current_column = None
+
+    def group(self, value, action):
+        query = self.build(value)
+        return f" {action} ".join(query)
+
+    def op(self, op, v):
+        assert self.current_column is not None
+        self.params.append(v)
+        op = QueryBuilder.operators[op]
+        return f'"{self.current_column}" {op} %s'
+
+    def build(self, where):
+        query = []
+        for k, v in where.items():
+            if k == '$and':
+                query.append(self.group(v, 'AND'))
+            elif k == '$or':
+                query.append(self.group(v, 'OR'))
+            else:
+                if k in QueryBuilder.operators:
+                    query.append(self.op(k, v))
+                elif isinstance(v, dict):
+                    assert self.current_column is None, \
+                        f"Fields in '{self.current_column}' can't be nested."
+                    old_current_column = self.current_column
+                    self.current_column = k
+                    query.append(self.group(v, 'AND'))
+                    self.current_column = old_current_column
+                else:
+                    query.append(f'{k}=%s')
+                    self.params.append(v)
+
+        return query
+
+    @staticmethod
+    def build_query(where):
+        builder = QueryBuilder()
+        query = builder.group(where, 'AND')
+        return {
+            'query': query,
+            'params': builder.params
+        }
+
+
+@app.route('/delete', methods=['post'])
+def delete():
+    req = request.json
+    table = req['table']
+    where = req['where']
+
+    query = QueryBuilder.build_query(where)
+    where_str = ""
+    if len(query['query']) > 0:
+        where_str = f"WHERE ({query['query']}) "
+    sql = f"DELETE FROM {table} {where_str} RETURNING *"
+    with SimplePostgres() as cur:
+        cur.execute(sql, query['params'])
+        return jsonify(cur.fetchall())
+
+
+@app.route('/select', methods=['post'])
+def select():
+    req = request.json
+    table = req['table']
+    where = req['where']
+
+    query = QueryBuilder.build_query(where)
+    sql = f"SELECT * FROM {table} WHERE ({query['query']})"
+    with SimplePostgres() as cur:
+        cur.execute(sql, query['params'])
+        return jsonify(cur.fetchall())
+
+
+@app.route('/update', methods=['post'])
+def update():
+    req = request.json
+    table = req['table']
+    where = req.get('where', {})
+    values = sorted(req['values'].items())
+    update_params = list(map(lambda x: x[1], values))
+    update_str = ','.join(map(lambda x: f'"{x[0]}" = %s', values))
+
+    # use an optional select string
+    query = QueryBuilder.build_query(where)
+    update_params.extend(query['params'])
+    where_str = ""
+    if len(query['query']) > 0:
+        where_str = f"WHERE ({query['query']}) "
+
+    sql = (f"UPDATE {table} SET {update_str} {where_str}"
+           "RETURNING *")
+    with SimplePostgres() as cur:
+        cur.execute(sql, update_params)
+        return jsonify(cur.fetchall())
+
+
+@app.route('/tables/drop', methods=['post'])
+def tables_drop():
+    req = request.json
+    table = req['table']
+
+    sql = f"DROP TABLE {table}"
+    with SimplePostgres() as cur:
+        cur.execute(sql)
+        return jsonify([])
+
+
+@app.route('/tables/create', methods=['post'])
+def tables_create():
+    req = request.json
+    table = req['table']
+    columns = req['columns']
+    columns_params = []
+
+    for k, v in sorted(columns.items()):
+        columns_params.append(f"{k} {str(v)}")
+
+    columns_str = ','.join(columns_params)
+    sql = f"CREATE TABLE {table} ({columns_str})"
+    with SimplePostgres() as cur:
+        cur.execute(sql)
+        return jsonify({})
 
 
 def app_error(e):
     print(traceback.format_exc())
-    return jsonify({"message": repr(e)}), 400
+    return jsonify({'message': repr(e)}), 400
 
 
 if __name__ == "__main__":

--- a/app.py
+++ b/app.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import json
 import os

--- a/app.py
+++ b/app.py
@@ -4,7 +4,7 @@ import json
 import os
 import traceback
 
-from flask import Flask, request, make_response
+from flask import Flask, jsonify, make_response, request
 
 import psycopg2
 from psycopg2.extras import RealDictCursor
@@ -43,5 +43,10 @@ def execute():
     return resp
 
 
+def app_error(e):
+    return jsonify({"message": str(e)}), 400
+
+
 if __name__ == "__main__":
+    app.register_error_handler(Exception, app_error)
     app.run(host='0.0.0.0', port=8000)

--- a/app.py
+++ b/app.py
@@ -30,5 +30,7 @@ def app_error(e):
 
 
 if __name__ == "__main__":
+    assert 'POSTGRES_DSN' in os.environ, \
+        "The environment variable 'POSTGRES_DSN' must be set."
     app.register_error_handler(Exception, app_error)
     app.run(host='0.0.0.0', port=8000)

--- a/app.py
+++ b/app.py
@@ -21,7 +21,8 @@ def postgres_dsn():
 
 class SimplePostgres:
     """
-    Provides a cursor to connection to Postgres instance in a with context.
+    Provides a cursor to a connection to a Postgres instance
+    in a 'with' context.
     """
 
     def __enter__(self):
@@ -38,8 +39,10 @@ class SimplePostgres:
     def __exit__(self, exc_type, exc_value, traceback):
         try:
             self.conn.commit()
-        # There's an exception listener, so we want to re-raise the exception
-        # But make sure all connections are properly closed
+        # There's a global exception listener, so we want to re-raise
+        # the exceptions.
+        # However, we need to make sure that all connections and cursors
+        # are properly closed
         except Exception as e:
             raise e
         finally:

--- a/app.py
+++ b/app.py
@@ -21,7 +21,7 @@ def execute():
                           cursor_factory=RealDictCursor) as conn:
         with conn.cursor() as cur:
             cur.execute(query, args)
-            return cur.fetchall()
+            return jsonify(cur.fetchall())
 
 
 def app_error(e):

--- a/microservice.yml
+++ b/microservice.yml
@@ -3,6 +3,131 @@ lifecycle:
   startup:
     command: ["python", "/app/app.py"]
 actions:
+  create_table:
+    help: Create a table
+    http:
+      path: /tables/create
+      port: 8000
+      method: post
+      contentType: application/json
+    arguments:
+      table:
+        help: The table to create
+        required: true
+        in: requestBody
+        type: string
+      columns:
+        help: |
+          A map of the to be created columns with their respective types
+          Please refer to
+          https://www.postgresql.org/docs/9.1/sql-createtable.html for more help.
+        required: true
+        in: requestBody
+        type: map
+  drop_table:
+    help: Drop a table
+    http:
+      path: /tables/drop
+      port: 8000
+      method: post
+      contentType: application/json
+    arguments:
+      table:
+        help: The table to drop
+        required: true
+        in: requestBody
+        type: string
+  insert:
+    help: Insert one or more entries into a table
+    http:
+      path: /insert
+      port: 8000
+      method: post
+      contentType: application/json
+    arguments:
+      table:
+        help: The table to insert entries into
+        required: true
+        in: requestBody
+        type: string
+      values:
+        help: |
+          A map or a list of maps with the values to insert into the table.
+        required: true
+        in: requestBody
+        type: any
+  select:
+    help: Select entries from a table
+    http:
+      path: /select
+      port: 8000
+      method: post
+      contentType: application/json
+    arguments:
+      table:
+        help: The table to select entries from
+        required: true
+        in: requestBody
+        type: string
+      where:
+        help: |
+          A query string of the parameters to filter on, e.g.
+          `{'columnName1': 'value2', 'columnName2': 'value2'}`
+          Use `{'$or': {cond1, cond2}} for `OR` chains.
+          Use e.g. `{'columName': {'$gt': 20}}} for more advanced comparisons.
+        required: true
+        in: requestBody
+        type: any
+  update:
+    help: Update entries in a table
+    http:
+      path: /update
+      port: 8000
+      method: post
+      contentType: application/json
+    arguments:
+      table:
+        help: The table to update entries in
+        required: true
+        in: requestBody
+        type: string
+      values:
+        help: |
+          A map of values to update.
+        required: true
+        in: requestBody
+        type: map
+      where:
+        help: |
+          A query string of the parameters to filter on, e.g.
+          `{'columnName1': 'value2', 'columnName2': 'value2'}`
+          Use `{'$or': {cond1, cond2}} for `OR` chains.
+          Use e.g. `{'columName': {'$gt': 20}}} for more advanced comparisons.
+        required: false
+        in: requestBody
+        type: any
+  delete:
+    help: Delete entries from a table
+    http:
+      path: /delete
+      port: 8000
+      method: post
+      contentType: application/json
+    arguments:
+      table:
+        help: The table to delete entries from
+        required: true
+        in: requestBody
+        type: string
+      where:
+        help: |
+          A query string of the parameters to filter on, e.g.
+          `{'columnName1': 'value2', 'columnName2': 'value2'}`
+          Use `{'$or': {cond1, cond2}} for `OR` chains.
+          Use e.g. `{'columName': {'$gt': 20}}} for more advanced comparisons.
+        required: false
+        in: requestBody
+        type: any
   exec:
     help: Run a SELECT statement
     http:


### PR DESCRIPTION
- Rolled a simple query builder for a clean syntax (it's far from perfect, but should get us started)
- I added {create,drop}_table as they are required to play with this fully in OMG/Storyscript

The README examples should explain a lot, but here's the condensed summary:


```coffee
# Storyscript
psql create_table table: 'books' columns: {
  'id': 'serial primary key',
  'title': 'varchar(100)'
}


psql insert table: 'books' values: {'title': 'Ulysses'}
# result: {'id': 1, 'title': 'Ulysses'}

psql insert table: 'books' values: [{'title': 'Moby Dick'}, {'title': 'War and Peace'}]
# result: [{'id': 2, 'title': 'Ulysses'}, {'id': 3, 'title': 'War and Peace'}]


psql select table: 'books' where: {'title': 'Moby Dick'}
# result: [{'id': 2, title: 'Moby Dick'}]

psql select table: 'books' where: {'$or': {'title': 'Moby Dick', 'id': {'$lt': 2}}}
# result: [{'id': 1, 'title': 'Ulysses'}, {'id': 2, 'title': 'Moby Dick'}]


psql update table: 'books' values: {'title': 'UPDATED'} where: {'id': {'$gt': 2}}
# result: [{'id': 3, 'title': 'UPDATED'}]

psql update table: 'books' values: {'title': 'UPDATED'}
# result: [
#     {'id': 1, 'title': 'Ulysses'},
#     {'id': 2, 'title': 'Ulysses'},
#     {'id': 3, 'title': 'War and Peace'}
# ]


psql delete table: 'books' where: {'title': 'Moby Dick'}
# result: [{'id': 2, 'title': 'Moby Dick'}]

psql drop_table table: 'books'
```